### PR TITLE
native: add loong64 to little endian architectures

### DIFF
--- a/endian_big.go
+++ b/endian_big.go
@@ -1,3 +1,4 @@
+//go:build mips || mips64 || ppc64 || s390x
 // +build mips mips64 ppc64 s390x
 
 package native

--- a/endian_generic.go
+++ b/endian_generic.go
@@ -1,3 +1,4 @@
+//go:build !mips && !mips64 && !ppc64 && !s390x && !amd64 && !386 && !arm && !arm64 && !mipsle && !mips64le && !ppc64le && !riscv64 && !wasm
 // +build !mips,!mips64,!ppc64,!s390x,!amd64,!386,!arm,!arm64,!mipsle,!mips64le,!ppc64le,!riscv64,!wasm
 
 // This file is a fallback, so that package native doesn't break

--- a/endian_generic.go
+++ b/endian_generic.go
@@ -1,5 +1,5 @@
-//go:build !mips && !mips64 && !ppc64 && !s390x && !amd64 && !386 && !arm && !arm64 && !mipsle && !mips64le && !ppc64le && !riscv64 && !wasm
-// +build !mips,!mips64,!ppc64,!s390x,!amd64,!386,!arm,!arm64,!mipsle,!mips64le,!ppc64le,!riscv64,!wasm
+//go:build !mips && !mips64 && !ppc64 && !s390x && !amd64 && !386 && !arm && !arm64 && !loong64 && !mipsle && !mips64le && !ppc64le && !riscv64 && !wasm
+// +build !mips,!mips64,!ppc64,!s390x,!amd64,!386,!arm,!arm64,!loong64,!mipsle,!mips64le,!ppc64le,!riscv64,!wasm
 
 // This file is a fallback, so that package native doesn't break
 // the instant the Go project adds support for a new architecture.

--- a/endian_little.go
+++ b/endian_little.go
@@ -1,5 +1,5 @@
-//go:build amd64 || 386 || arm || arm64 || mipsle || mips64le || ppc64le || riscv64 || wasm
-// +build amd64 386 arm arm64 mipsle mips64le ppc64le riscv64 wasm
+//go:build amd64 || 386 || arm || arm64 || loong64 || mipsle || mips64le || ppc64le || riscv64 || wasm
+// +build amd64 386 arm arm64 loong64 mipsle mips64le ppc64le riscv64 wasm
 
 package native
 

--- a/endian_little.go
+++ b/endian_little.go
@@ -1,3 +1,4 @@
+//go:build amd64 || 386 || arm || arm64 || mipsle || mips64le || ppc64le || riscv64 || wasm
 // +build amd64 386 arm arm64 mipsle mips64le ppc64le riscv64 wasm
 
 package native


### PR DESCRIPTION
Just double checked with https://github.com/golang/go/blob/master/src/cmd/internal/sys/arch.go and it appears `loong64` is the only value that wasn't accounted for in the current master branch.

Thanks again!